### PR TITLE
naprawa błędów z api

### DIFF
--- a/postman/Faily_api_test_collection.postman_collection.json
+++ b/postman/Faily_api_test_collection.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "7259397f-4f52-4e7b-8db4-10e50574ee69",
+		"_postman_id": "8113a14a-9f74-4983-b7ae-a20b66be79b0",
 		"name": "Faily_api_test_collection",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "44286390"
@@ -67,7 +67,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\r\n    \"name\": \"Test Api User\",\r\n    \"email\": \"marek@example.com\",\r\n    \"password\": \"password123\",\r\n    \"password_confirmation\": \"password123\",\r\n    \"first_name\": \"Marek\",\r\n    \"last_name\": \"Marucha\",\r\n    \"age\": \"15\",\r\n    \"phone\": \"+48 213719990\",\r\n    \"description\": \"użytkonik stworzony do testowania api\",\r\n    \"language\": \"pl\"\r\n}",
+					"raw": "{\r\n    \"name\": \"Test Api User\",\r\n    \"email\": \"pieczarek@example.com\",\r\n    \"password\": \"password123\",\r\n    \"password_confirmation\": \"password123\",\r\n    \"first_name\": \"Marek\",\r\n    \"last_name\": \"Marucha\",\r\n    \"age\": \"15\",\r\n    \"phone\": \"+48 213719990\",\r\n    \"description\": \"użytkonik stworzony do testowania api\",\r\n    \"language\": \"pl\"\r\n}",
 					"options": {
 						"raw": {
 							"language": "json"
@@ -124,7 +124,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\r\n  \"email\": \"marek@example.com\",\r\n  \"password\": \"password123\"\r\n}",
+					"raw": "{\r\n  \"email\": \"pieczarek@example.com\",\r\n  \"password\": \"password123\"\r\n}",
 					"options": {
 						"raw": {
 							"language": "json"
@@ -180,9 +180,25 @@
 			"name": "Get Events",
 			"request": {
 				"method": "GET",
-				"header": [],
+				"header": [
+					{
+						"key": "Authorization",
+						"value": "Bearer {{token}}",
+						"type": "text"
+					},
+					{
+						"key": "Accept",
+						"value": "application/json",
+						"type": "text"
+					},
+					{
+						"key": "X-XSRF-TOKEN",
+						"value": "{{csrf_token}}",
+						"type": "text"
+					}
+				],
 				"url": {
-					"raw": "{{base_url}}/events?Authorization=Bearer {{token}}&Accept=application/json&X-XSRF-TOKEN={{csrf_token}}",
+					"raw": "{{base_url}}/events",
 					"host": [
 						"{{base_url}}"
 					],
@@ -191,16 +207,19 @@
 					],
 					"query": [
 						{
-							"key": "Authorization",
-							"value": "Bearer {{token}}"
+							"key": "",
+							"value": "",
+							"disabled": true
 						},
 						{
-							"key": "Accept",
-							"value": "application/json"
+							"key": "",
+							"value": "",
+							"disabled": true
 						},
 						{
-							"key": "X-XSRF-TOKEN",
-							"value": "{{csrf_token}}"
+							"key": "",
+							"value": "",
+							"disabled": true
 						}
 					]
 				}
@@ -220,6 +239,16 @@
 					{
 						"key": "X-XSRF-TOKEN",
 						"value": "{{csrf_token}}",
+						"type": "text"
+					},
+					{
+						"key": "Authorization",
+						"value": "Bearer {{token}}",
+						"type": "text"
+					},
+					{
+						"key": "Accept",
+						"value": "application/json",
 						"type": "text"
 					}
 				],

--- a/src/routes/api.php
+++ b/src/routes/api.php
@@ -11,80 +11,94 @@ use App\Http\Controllers\Api\RideRequestController;
 use App\Http\Controllers\Api\TestApiController;
 use Illuminate\Support\Facades\Http;
 
-Route::prefix('api')->name('api.')->group(function ()
-{
-    Route::get("/test", [TestApiController::class, "test"]);
-    Route::post('/register', [AuthController::class, 'register']);
-    Route::post('/login', [AuthController::class, 'login']);
+Route::get("/test", [TestApiController::class, "test"]);
+Route::post('/register', [AuthController::class, 'register']);
+Route::post('/login', [AuthController::class, 'login']);
 
-    Route::middleware('auth:sanctum')->group(function () {
-        // Auth
-        Route::post('/logout', [AuthController::class, 'logout']);
-        Route::get('/me', [AuthController::class, 'me']);
+Route::middleware('auth:sanctum')->group(function () {
+    Route::post('/logout', [AuthController::class, 'logout']);
+    Route::get('/me', [AuthController::class, 'me']);
 
-        Route::prefix('user')->group(function () {
-            Route::get('/', [UserController::class, 'me']);
-            Route::put('/', [UserController::class, 'update']);
-            Route::post('/photo', [UserController::class, 'updatePhoto']);
-            Route::put('/password', [UserController::class, 'updatePassword']);
-            Route::put('/settings', [UserController::class, 'updateSettings']);
-        });
-
-        Route::apiResource('events', EventController::class);
-        Route::get('/events/popular', [EventController::class, 'popular']);
-        Route::get('/events/upcoming', [EventController::class, 'upcoming']);
-
-        Route::get('/events/{event}/attendees', [EventAttendeeController::class, 'index']);
-        Route::post('/events/{event}/attendees', [EventAttendeeController::class, 'store']);
-        Route::patch('/events/{event}/attendees/{attendee}', [EventAttendeeController::class, 'update']);
-        Route::delete('/events/{event}/attendees/{attendee}', [EventAttendeeController::class, 'destroy']);
-        Route::get('/my-attending', [EventAttendeeController::class, 'myEvents']);
-        Route::get('/my-attendees', [EventAttendeeController::class, 'myAttendees']);
-
-        Route::get('/events/{event}/photos', [PhotoController::class, 'index']);
-        Route::post('/photos', [PhotoController::class, 'store']);
-        Route::delete('/photos/{photo}', [PhotoController::class, 'destroy']);
-
-        Route::apiResource('rides', RideController::class);
-
-        Route::apiResource('ride-requests', RideRequestController::class)->except(['show.blade.php', 'edit']);
-        Route::get('/my-ride-requests', [RideRequestController::class, 'myRequests']);
-
-        Route::get('/geocode/search', 'GeocodingController@search');
-        Route::get('/geocode/reverse', 'GeocodingController@reverse');
-    });
-    Route::get('/nominatim/search', function (\Illuminate\Http\Request $request) {
-        $q = $request->query('q');
-        $limit = $request->query('limit', 5);
-
-        $response = Http::withHeaders([
-            'User-Agent' => 'YourAppName/1.0 (you@example.com)'
-        ])->get('https://nominatim.openstreetmap.org/search', [
-            'format' => 'json',
-            'q' => $q,
-            'limit' => $limit,
-        ]);
-
-        \Log::info("Response body: " . $response->body());
-        \Log::info("Response status: " . $response->status());
-
-        return $response->json();
+    Route::prefix('user')->group(function () {
+        Route::get('/', [UserController::class, 'me']);
+        Route::put('/', [UserController::class, 'update']);
+        Route::post('/photo', [UserController::class, 'updatePhoto']);
+        Route::put('/password', [UserController::class, 'updatePassword']);
+        Route::put('/settings', [UserController::class, 'updateSettings']);
     });
 
-    Route::get('/nominatim/reverse', function (\Illuminate\Http\Request $request) {
-        $lat = $request->query('lat');
-        $lon = $request->query('lon');
+    Route::apiResource('events', EventController::class)->names([
+        'index' => 'api.events.index',
+        'store' => 'api.events.store',
+        'show' => 'api.events.show',
+        'update' => 'api.events.update',
+        'destroy' => 'api.events.destroy',
+    ]);
 
-        $response = Http::withHeaders([
-            'User-Agent' => 'YourAppName/1.0 (you@example.com)'
-        ])->get('https://nominatim.openstreetmap.org/reverse', [
-            'format' => 'json',
-            'lat' => $lat,
-            'lon' => $lon,
-        ]);
+    Route::get('/events/popular', [EventController::class, 'popular']);
+    Route::get('/events/upcoming', [EventController::class, 'upcoming']);
 
-        return $response->json();
-    });
+    Route::get('/events/{event}/attendees', [EventAttendeeController::class, 'index']);
+    Route::post('/events/{event}/attendees', [EventAttendeeController::class, 'store']);
+    Route::patch('/events/{event}/attendees/{attendee}', [EventAttendeeController::class, 'update']);
+    Route::delete('/events/{event}/attendees/{attendee}', [EventAttendeeController::class, 'destroy']);
+    Route::get('/my-attending', [EventAttendeeController::class, 'myEvents']);
+    Route::get('/my-attendees', [EventAttendeeController::class, 'myAttendees']);
+
+    Route::get('/events/{event}/photos', [PhotoController::class, 'index']);
+    Route::post('/photos', [PhotoController::class, 'store']);
+    Route::delete('/photos/{photo}', [PhotoController::class, 'destroy']);
+
+    Route::apiResource('rides', RideController::class)->names([
+        'index' => 'api.rides.index',
+        'store' => 'api.rides.store',
+        'show' => 'api.rides.show',
+        'update' => 'api.rides.update',
+        'destroy' => 'api.rides.destroy',
+    ]);
+
+    Route::apiResource('ride-requests', RideRequestController::class)->except(['show', 'edit'])->names([
+        'index' => 'api.ride-requests.index',
+        'store' => 'api.ride-requests.store',
+        'update' => 'api.ride-requests.update',
+        'destroy' => 'api.ride-requests.destroy',
+    ]);
+
+    Route::get('/my-ride-requests', [RideRequestController::class, 'myRequests']);
+
+    Route::get('/geocode/search', 'GeocodingController@search');
+    Route::get('/geocode/reverse', 'GeocodingController@reverse');
 });
 
+Route::get('/nominatim/search', function (\Illuminate\Http\Request $request) {
+    $q = $request->query('q');
+    $limit = $request->query('limit', 5);
 
+    $response = Http::withHeaders([
+        'User-Agent' => 'YourAppName/1.0 (you@example.com)'
+    ])->get('https://nominatim.openstreetmap.org/search', [
+        'format' => 'json',
+        'q' => $q,
+        'limit' => $limit,
+    ]);
+
+    \Log::info("Response body: " . $response->body());
+    \Log::info("Response status: " . $response->status());
+
+    return $response->json();
+});
+
+Route::get('/nominatim/reverse', function (\Illuminate\Http\Request $request) {
+    $lat = $request->query('lat');
+    $lon = $request->query('lon');
+
+    $response = Http::withHeaders([
+        'User-Agent' => 'YourAppName/1.0 (you@example.com)'
+    ])->get('https://nominatim.openstreetmap.org/reverse', [
+        'format' => 'json',
+        'lat' => $lat,
+        'lon' => $lon,
+    ]);
+
+    return $response->json();
+});

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -77,4 +77,4 @@ Route::middleware(['auth', 'verified', 'locale', 'admin'])->prefix('admin')->nam
 Route::middleware(['auth', 'locale'])->post('/users/{id}/report', [ReportController::class, 'reportUser'])->name('users.report');
 
 require __DIR__.'/auth.php';
-require __DIR__ . '/api.php';
+


### PR DESCRIPTION
napotkałem błędy związane z podwójnym prefixem api w zapytaniach api. RouteServiceProvider samo dodaje to więc musaiłęm usunąć prefix i name z api.php i przy okazji naprawić błąd w zapytaniach postman 
